### PR TITLE
add ability to call try lock, that acquires or return

### DIFF
--- a/lib/pg_advisory_lock.rb
+++ b/lib/pg_advisory_lock.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'pg_advisory_lock/version'
+require 'pg_advisory_lock/lock_not_obtained'
 require 'pg_advisory_lock/base'
 
 module PgAdvisoryLock

--- a/lib/pg_advisory_lock/lock_not_obtained.rb
+++ b/lib/pg_advisory_lock/lock_not_obtained.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
 module PgAdvisoryLock
-  VERSION = '0.3.0'
+  class LockNotObtained < StandardError
+  end
 end

--- a/spec/pg_advisory_lock_base/transaction_lock_spec.rb
+++ b/spec/pg_advisory_lock_base/transaction_lock_spec.rb
@@ -68,5 +68,76 @@ RSpec.describe PgAdvisoryLock::Base do
       expect(within_transaction?).to eq(false)
       expect(PgSqlCaller::Base.transaction_open?).to eq(false)
     end
+
+    it 'with 2 threads using #with_lock' do
+      first_lock = nil
+      second_lock = nil
+
+      Thread.new do
+        PgAdvisoryLock::Base.with_lock(:test1) do
+          first_lock = 'locked'
+          sleep 2
+        end
+        first_lock = 'unlocked'
+      end
+
+      sleep 1 # wait for first thread to acquire lock
+
+      Thread.new do
+        PgAdvisoryLock::Base.with_lock(:test1) do
+          second_lock = 'locked'
+          expect(first_lock).to eq('unlocked') # first lock must be already unlocked
+          sleep 0.1
+        end
+        second_lock = 'unlocked'
+      end
+
+      sleep 0.2 # wait second thread to start acquiring lock (and blocked in waiting mode)
+
+      expect(first_lock).to eq('locked')
+      expect(second_lock).to be_nil
+
+      sleep 1 # wait both locks are unlocked (sleep total 2.2 > lock duration total 2.1)
+
+      expect(first_lock).to eq('unlocked')
+      expect(second_lock).to eq('unlocked')
+    end
+
+    it 'with 2 threads using #try_lock' do
+      first_lock = nil
+      second_lock = nil
+
+      Thread.new do
+        PgAdvisoryLock::Base.try_lock(:test1) do
+          first_lock = 'locked'
+          sleep 2
+        end
+        first_lock = 'unlocked'
+      end
+
+      sleep 1 # wait for first thread to acquire lock
+
+      Thread.new do
+        begin
+          PgAdvisoryLock::Base.try_lock(:test1) do
+            second_lock = 'locked'
+          end
+          second_lock = 'unlocked'
+        rescue PgAdvisoryLock::LockNotObtained => e
+          second_lock = 'lock_not_obtained'
+          expect(first_lock).to eq('locked') # first lock must be still locked
+        end
+      end
+
+      sleep 0.2 # wait second thread to try acquiring lock and fail
+
+      expect(first_lock).to eq('locked')
+      expect(second_lock).to eq('lock_not_obtained')
+
+      sleep 1 # wait both locks are unlocked (sleep total 2.2 > lock duration total 2.0)
+
+      expect(first_lock).to eq('unlocked')
+      expect(second_lock).to eq('lock_not_obtained')
+    end
   end
 end


### PR DESCRIPTION
add support `pg_try_advisory_lock`, `pg_try_advisory_xact_lock`, `pg_try_advisory_lock_shared`, `pg_try_advisory_xact_lock_shared`

lock that does not wait when the resource is already locked, and return immediately.
similar to `LOCK NO WAIT`

see https://www.postgresql.org/docs/12/functions-admin.html#FUNCTIONS-ADVISORY-LOCKS